### PR TITLE
Add random verse generation for en-lsv (with optional daily Action)

### DIFF
--- a/.github/workflows/generate-en-lsv-random.yml
+++ b/.github/workflows/generate-en-lsv-random.yml
@@ -1,0 +1,19 @@
+name: Generate en-lsv random verse
+on:
+  schedule:
+    - cron: "0 0 * * *" # runs daily at midnight UTC
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install
+      - run: npm run generate:en-lsv
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update en-lsv random.json"

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,70 @@
+# Contributing to ScriptureFlow API
+
+First of all: thank you for your interest in contributing! 🙏  
+We’re excited to welcome developers, translators, documentation authors and other collaborators to the ScriptureFlow project.
+
+---
+
+## How you can contribute  
+We welcome contributions of all kinds:  
+- Reporting bugs  
+- Suggesting or implementing new versions/translations  
+- Improving documentation  
+- Adding tests, examples or SDKs  
+- Helping to triage or close issues  
+
+If you’re not sure where to start, browse our issue tracker and look for issues tagged `good-first-issue` or `help-wanted`.
+
+---
+
+## Your first contribution  
+1. Fork the repository.  
+2. Create a new branch: `git checkout --branch my-feature`.  
+3. Make your changes (follow any existing code/style conventions).  
+4. Commit your changes: `git commit -m "Add <feature> to ScriptureFlow"`.  
+5. Push the branch to your fork: `git push origin my-feature`.  
+6. Open a Pull Request to this repository’s `main` branch.  
+   - Provide a clear title and description.  
+   - Link to any relevant issue (if applicable).  
+   - Include tests/screenshots/documentation updates where relevant.  
+
+---
+
+## Pull Request Guidelines  
+- Ensure the code builds and passes any existing tests.  
+- If you’re adding a translation/version, follow the folder structure (`bibles/<version>/…`).  
+- Use meaningful commit messages.  
+- Be open to feedback and revision — maintainers may request changes.  
+- You may be asked to rebase or merge `main` changes before your PR is merged.  
+- Reviews may take 1–2 weeks — thanks for your patience.
+
+---
+
+## Style & Formatting  
+- Use spaces, not tabs (unless project dictates otherwise).  
+- Follow existing naming conventions for files and folders.  
+- For JSON schema changes, update documentation accordingly.  
+- When applicable, add or update tests/examples to reflect new behavior.
+
+---
+
+## Issue Guidelines  
+- Before creating a new issue, search existing issues to avoid duplicates.  
+- Provide a clear and descriptive title.  
+- For bugs: include steps to reproduce, expected vs. actual behavior, version used, environment.  
+- For enhancement requests: describe the benefit, proposed approach, any constraints.
+
+---
+
+## Community & Support  
+Need help?  
+- Post your question in the issue tracker with the tag `question`.  
+- Check the FAQ in the README for quick answers.  
+- Be respectful in all communications — we adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+## License & Attribution  
+By contributing you agree that your contributions will be licensed under the project’s MIT License.  
+See [LICENSE](LICENSE) for details.  
+Original project © Henok Woldesenbet, enhancements © 2025 Johnathan Lightfoot / ScriptureFlow Project.

--- a/License
+++ b/License
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Johnathan Lightfoot / ScriptureFlow Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -27,11 +27,36 @@ To make the Word of God **universally accessible** in every language and format 
 
 | Feature | Description |
 |----------|-------------|
-| **Modernized Architecture** | Refactored structure for cleaner endpoints and improved caching. |
-| **AI-Ready JSON Schema** | Structured for natural-language processing and semantic search. |
-| **Multilingual Expansion** | Enhanced support for translations, including underrepresented languages. |
-| **CDN-Optimized Access** | Faster global delivery with flexible versioning. |
+| **Modernized Architecture** | Initial refactor underway to simplify endpoint structure and improve caching. |
+| **AI-Ready JSON Schema** | Future updates will introduce an AI-ready JSON schema for natural-language processing and semantic search. |
+| **Multilingual Expansion** | Roadmap includes expanded multilingual support, with emphasis on underrepresented translations. |
+| **CDN-Optimized Access** | Delivered globally via jsDelivr CDN; future versions will add structured versioning for releases. |
 | **Community Maintenance** | Actively maintained and open for collaboration. |
+
+---
+
+## 🧩 Change Log & Progress Tracker
+
+This section documents the ongoing development and evolution of **ScriptureFlow** — ensuring transparency and helping contributors follow project milestones.
+
+| Status | Feature / Improvement | Description | Date |
+|:-------:|------------------------|--------------|:----:|
+| ✅ | **Fork Established** | ScriptureFlow created as an actively maintained continuation of the original Bible-API by Henok Woldesenbet. | Nov 2025 |
+| ✅ | **Repository Rebrand** | Updated branding, README, and documentation to reflect new project direction. | Nov 2025 |
+| 🛠️ | **Architecture Refactor (Phase 1)** | Simplifying endpoint structure for consistency and performance. | In Progress |
+| 🛠️ | **JSON Schema Review** | Designing AI/NLP-ready data model for verse and chapter metadata. | In Progress |
+| 🔜 | **Multilingual Expansion** | Adding support for new translations, including underrepresented languages. | Planned |
+| 🔜 | **Version Tagging & Releases** | Implementing semantic versioning for future API stability. | Planned |
+| 🔜 | **Audio Bible Integration** | Exploring inclusion of high-quality audio verse files via CDN. | Planned |
+| 🔜 | **Mobile SDKs** | Early-stage planning for SDKs for Android and iOS. | Planned |
+
+---
+
+📅 **Next Milestone:**  
+Release **v0.2.0** — featuring improved directory structure, standardized JSON output, and expanded test coverage.
+
+🧠 **Future Direction:**  
+Integration of AI-powered verse clustering, semantic search, and multilingual indexing using modern LLM pipelines.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,179 +1,92 @@
-# Bible API
+# ScriptureFlow API 🌊
 
-Welcome to Bible API, your go-to resource for easy access to Bible verses and chapters across multiple versions and languages. With a simple request, obtain the text of a specific verse or an entire chapter, perfect for developers, researchers, and Bible enthusiasts who want to incorporate the Holy Scripture into their applications, websites, or projects.
+**ScriptureFlow** is a modern, open-source platform for accessing the Holy Scriptures through a simple and reliable JSON API.  
+It builds upon the pioneering [Bible-API](https://github.com/wldeh/bible-api) by [Henok Woldesenbet](https://github.com/wldeh), honoring his foundational work while introducing a refreshed vision for performance, multilingual access, and AI-ready integration.
 
-## Overview
-
-- [Key Features](#key-features)
-- [Quick Start](#quick-start)
-- [API Endpoints](#api-endpoints)
-  - [Get a Verse](#get-a-verse)
-  - [Get a Chapter](#get-a-chapter)
-- [Supported Versions](#supported-versions)
-- [Examples](#examples)
-- [Potential Applications](#potential-applications)
-- [FAQs](#faqs)
-- [Contribute](#contribute)
-- [Licensing](#licensing)
-
-## Quick Start
-
-To begin using Bible API, no API keys or authentication are required. Simply send a request to the desired endpoint with the necessary parameters, and receive the data in JSON format.
-
-## API Endpoints
-
-### Get a Verse
-
-To obtain a specific verse, send a request to the following endpoint:
-
-```
-https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/${version}/books/${book}/chapters/${chapter}/verses/${verse}.json
-```
-
-Replace `${version}`, `${book}`, `${chapter}`, and `${verse}` with the appropriate values.
-
-**Parameters:**
-
-- `version`: The Bible version (e.g., `en-asv`, `en-kjv`)
-- `book`: The book of the Bible (e.g., `genesis`, `exodus`)
-- `chapter`: The chapter number
-- `verse`: The verse number
-
-### Get a Chapter
-
-To access an entire chapter, send a request to the following endpoint:
-
-```
-https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/${version}/books/${book}/chapters/${chapter}.json
-```
-
-Replace `${version}`, `${book}`, and `${chapter}` with the appropriate values.
-
-**Parameters:**
-
-- `version`: The Bible version (e.g., `en-asv`, `en-kjv`)
-- `book`: The book of the Bible (e.g., `genesis`, `exodus`)
-- `chapter`: The chapter number
-
-## Key Features
-
-- **Blazing Fast and Reliable**: Experience lightning-fast response times and exceptional reliability, ensuring a seamless and efficient integration with your applications and projects.
-- **Completely Free**: The Bible API is entirely free to use, making it accessible to everyone, regardless of budget constraints or project size.
-- **Access to Multiple Bible Versions**: The Bible API currently supports numerous Bible versions and is continuously expanding to include more translations, ensuring you have access to a diverse range of Scripture texts.
-- **Support for 300+ Languages**: Our goal is to cover over 300 languages and translations, making the Bible API one of the most comprehensive and inclusive resources for accessing the Holy Scripture in various languages.
-- **Regularly Updated and Maintained**: Our dedicated team regularly updates and maintains the Bible API, ensuring its accuracy, reliability, and continued improvement.
-- **Public Domain Versions**: Access public domain Bible versions without any copyright restrictions, allowing for a wide range of uses and applications.
-- **Simple and Easy-to-use API**: The Bible API's straightforward design and extensive documentation make it easy for developers of all skill levels to integrate it into their projects.
-- **Extensive Documentation**: Comprehensive documentation provides clear instructions, examples, and guidelines to help you make the most of the Bible API and its features.
-
-## Supported Versions
-
-Use the following endpoint to view a list of all available Bible versions:
-
-```
-https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/bibles.json
-```
-
-The response will display an array of Bible versions with their associated metadata, including the version ID, name, description, language, and more.
-
-## Examples
-
-In this section, you'll find examples demonstrating the use of Bible API, along with code snippets showcasing its implementation in various programming languages.
-
-**API Request Examples:**
-
-- Retrieve Genesis 1:1 in the American Standard Version (ASV):
-
-  ```
-  https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-asv/books/genesis/chapters/1/verses/1.json
-  ```
-
-- Fetch John 3:16 in the King James Version (KJV):
-
-  ```
-  https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-kjv/books/john/chapters/3/verses/16.json
-  ```
-
-- Access the complete chapter of Psalm 23 in the American Standard Version (ASV):
-
-  ```
-  https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-asv/books/psalms/chapters/23.json
-  ```
-
-**Code Snippets:**
-
-### JavaScript
-
-```javascript
-fetch(
-  "https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-asv/books/genesis/chapters/1/verses/1.json"
-)
-  .then((response) => response.json())
-  .then((data) => console.log(data.text));
-```
-
-### Python
-
-```python
-import requests
-
-response = requests.get("https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-asv/books/genesis/chapters/1/verses/1.json")
-data = response.json()
-print(data["text"])
-```
-
-### PHP
-
-```php
-$response = file_get_contents("https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/en-asv/books/genesis/chapters/1/verses/1.json");
-$data = json_decode($response, true);
-echo $data["text"];
-```
-
-## FAQs
-
-**Q: Is an API key or authentication needed to use Bible API?**
-
-A: No, Bible API does not require API keys or authentication. Simply send a request to the desired endpoint with the necessary parameters to receive the data in JSON format.
-
-**Q: How often are new Bible versions added to the API?**
-
-A: We continuously strive to add new Bible versions to the API. If you have a specific version you'd like to see included, please open an issue or contact a maintainer.
-
-**Q: Can I use Bible API for commercial purposes?**
-
-A: Yes, Bible API can be used for commercial purposes. However, be aware of copyright restrictions on some Bible versions. Consult the metadata of each version for information on their respective licenses.
-
-## Upcoming Features
-
-We are continuously working on improving and expanding the Bible API to provide you with the best possible experience. Here's a sneak peek at some of the exciting features we have planned for future releases:
-
-| Feature                                      | Description                                                                                  |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **Additional Bible Translations**            | Add support for 300+ languages                                                               |
-| **Natural Language Processing (NLP) Search** | Perform advanced searches using natural language queries                                     |
-| **Audio Bible Integration**                  | Access Bible verses with high-quality audio recordings                                       |
-| **Study Notes and Commentary**               | Access study notes and commentary from renowned Bible scholars                               |
-| **Bible Reading Plans**                      | Access a variety of Bible reading plans to help users read through the Bible consistently    |
-| **Bible Quiz and Trivia**                    | Test your Bible knowledge with fun quizzes and trivia questions                              |
-| **Verses of the Day**                        | Access a daily curated verse through a dedicated endpoint                                    |
-| **Mobile SDKs for iOS and Android**          | Easily integrate the Bible API into mobile apps with our official SDKs                       |
-| **AI-Generated Bible Summaries**             | Receive concise, AI-generated summaries of Bible chapters and stories                        |
-| **Sentiment Analysis**                       | Analyze the sentiment of Bible verses and passages using AI algorithms                       |
-| **AI-Powered Verse Clustering**              | Discover related verses and passages through AI-powered clustering and grouping              |
-| **Personalized AI-Generated Bible Studies**  | Experience tailored Bible studies generated by AI based on preferences and interests         |
-| **AI-Driven Scripture Insights**             | Unlock deeper insights into Bible verses using cutting-edge AI analysis techniques           |
-| **AI-Generated Bible-Verse-to-Image**        | Receive beautiful, AI-generated images inspired by Bible verses                              |
-| **Conversational AI for Bible Study**        | Interact with an AI-powered virtual assistant to guide you through your Bible study sessions |
-
-## Contribute
-
-We encourage contributions to enhance and expand Bible API. For suggestions, or feature requests, please open an issue on our GitHub repository. If you'd like to contribute, feel free to submit a pull request. A contributing guide is under development.
-
-## Licensing
-
-Bible API is available under the [MIT License](LICENSE). The text of the Bible versions provided by the API may have additional copyright restrictions. Consult the metadata of each version for information on their respective licenses.
+> “The Word became flesh and dwelt among us.” — John 1:14  
+> ScriptureFlow brings the Word into today’s digital world — accessible, structured, and free.
 
 ---
 
-Crafted with 💙 by the Bible API Team. Enjoy!
+## 🙏 Credits & Origins
+
+This project would not exist without the groundwork of **Henok Woldesenbet** and his original **Bible-API**.  
+Full credit is given for his early contributions that made Scripture data freely accessible to developers worldwide.
+
+ScriptureFlow carries that legacy forward — expanding, modernizing, and maintaining it as a living, community-driven project.
+
+---
+
+## 🌍 Vision
+
+To make the Word of God **universally accessible** in every language and format — empowering developers, ministries, and educators to integrate Scripture seamlessly into digital experiences.
+
+---
+
+## 🚀 What’s New in ScriptureFlow
+
+| Feature | Description |
+|----------|-------------|
+| **Modernized Architecture** | Refactored structure for cleaner endpoints and improved caching. |
+| **AI-Ready JSON Schema** | Structured for natural-language processing and semantic search. |
+| **Multilingual Expansion** | Enhanced support for translations, including underrepresented languages. |
+| **CDN-Optimized Access** | Faster global delivery with flexible versioning. |
+| **Community Maintenance** | Actively maintained and open for collaboration. |
+
+---
+
+## ⚡ Quick Start
+
+No authentication or API key required. Just call the endpoint:
+
+```bash
+https://cdn.jsdelivr.net/gh/scriptureflow/bibles/en-kjv/books/john/chapters/3/verses/16.json
+```
+
+### Parameters
+
+- **version** – Bible version (e.g., `en-kjv`, `en-asv`)
+- **book** – Book name (e.g., `john`, `genesis`)
+- **chapter** – Chapter number
+- **verse** – Verse number *(optional for full chapter)*
+
+---
+
+## 📚 Example Usage
+
+### JavaScript
+fetch("https://cdn.jsdelivr.net/gh/scriptureflow/bibles/en-asv/books/genesis/chapters/1/verses/1.json")
+  .then(res => res.json())
+  .then(data => console.log(data.text));
+
+### Python
+import requests
+r = requests.get("https://cdn.jsdelivr.net/gh/scriptureflow/bibles/en-asv/books/john/chapters/3/verses/16.json")
+print(r.json()["text"])
+
+## 💡 Roadmap
+
+- ✅ Core API refactor  
+- 🔄 Add multilingual indexing  
+- 🧠 AI search + verse clustering  
+- 🎧 Audio Bible integration  
+- 📱 Mobile SDKs (iOS + Android)
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome! Whether you’re adding new translations, improving code, or enhancing documentation, open an issue or submit a pull request.
+
+---
+
+## ⚖️ License
+
+Licensed under the [MIT License](LICENSE).  
+Original work © Henok Woldesenbet.  
+Enhancements and refactor © 2025 Johnathan Lightfoot / ScriptureFlow Project.
+
+---
+
+Crafted with 💙 by the **ScriptureFlow Team** —  
+*Where the Word Moves Freely.*

--- a/bibles/en-lsv/random.json
+++ b/bibles/en-lsv/random.json
@@ -1,0 +1,8 @@
+{
+  "version": "en-lsv",
+  "reference": "luke 5:7",
+  "book": "luke",
+  "chapter": 5,
+  "verse": 7,
+  "text": "and they beckoned to the partners who [are] in the other boat, having come, to help them; and they came, and filled both the boats, so that they were sinking."
+}

--- a/scripts/generate-en-lsv-random.js
+++ b/scripts/generate-en-lsv-random.js
@@ -1,0 +1,90 @@
+// scripts/generate-en-lsv-random.js
+
+const fs = require("fs");
+const path = require("path");
+
+const VERSION = "en-lsv";
+const ROOT = process.cwd();
+const BIBLES_DIR = path.join(ROOT, "bibles");
+const VERSION_DIR = path.join(BIBLES_DIR, VERSION);
+const BOOKS_DIR = path.join(VERSION_DIR, "books");
+
+if (!fs.existsSync(VERSION_DIR)) {
+  console.error(`Version directory not found: ${VERSION_DIR}`);
+  process.exit(1);
+}
+if (!fs.existsSync(BOOKS_DIR)) {
+  console.error(`Books directory not found: ${BOOKS_DIR}`);
+  process.exit(1);
+}
+
+const allVerses = [];
+
+const books = fs
+  .readdirSync(BOOKS_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name);
+
+for (const book of books) {
+  const chaptersDir = path.join(BOOKS_DIR, book, "chapters");
+  if (!fs.existsSync(chaptersDir)) continue;
+
+  const chapters = fs
+    .readdirSync(chaptersDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+
+  for (const chapter of chapters) {
+    const versesDir = path.join(chaptersDir, chapter, "verses");
+    if (!fs.existsSync(versesDir)) continue;
+
+    const verseFiles = fs
+      .readdirSync(versesDir, { withFileTypes: true })
+      .filter((d) => d.isFile() && d.name.endsWith(".json"))
+      .map((d) => d.name);
+
+    for (const verseFile of verseFiles) {
+      const verseNumber = verseFile.replace(".json", "");
+
+      const cdnUrl = `https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/${VERSION}/books/${book}/chapters/${chapter}/verses/${verseNumber}.json`;
+
+      allVerses.push({
+        version: VERSION,
+        book,
+        chapter: Number(chapter),
+        verse: Number(verseNumber),
+        path: `bibles/${VERSION}/books/${book}/chapters/${chapter}/verses/${verseNumber}.json`,
+        cdn_url: cdnUrl,
+      });
+    }
+  }
+}
+
+// write index.json
+const indexPath = path.join(VERSION_DIR, "index.json");
+fs.writeFileSync(indexPath, JSON.stringify(allVerses, null, 2), "utf8");
+console.log(`Wrote ${allVerses.length} verses to ${indexPath}`);
+
+// pick random
+if (allVerses.length === 0) {
+  console.error("No verses found for en-lsv. Exiting.");
+  process.exit(1);
+}
+
+const picked = allVerses[Math.floor(Math.random() * allVerses.length)];
+
+const verseFileAbsolute = path.join(ROOT, picked.path);
+const verseJson = JSON.parse(fs.readFileSync(verseFileAbsolute, "utf8"));
+
+const randomOut = {
+  version: picked.version,
+  reference: `${picked.book} ${picked.chapter}:${picked.verse}`,
+  book: picked.book,
+  chapter: picked.chapter,
+  verse: picked.verse,
+  text: verseJson.text,
+};
+
+const randomPath = path.join(VERSION_DIR, "random.json");
+fs.writeFileSync(randomPath, JSON.stringify(randomOut, null, 2), "utf8");
+console.log(`Wrote random verse to ${randomPath}`);


### PR DESCRIPTION
### Summary
This pull request adds support for generating random verses from the **en-lsv** Bible version.

It includes:
- `scripts/generate-en-lsv-random.js`: Script that walks through all verses, builds `index.json`, and selects one random verse to save as `random.json`.
- `bibles/en-lsv/index.json`: Full index of verses for the en-lsv version.
- `bibles/en-lsv/random.json`: One randomly chosen verse, refreshed each time the script runs.
- `.github/workflows/generate-en-lsv-random.yml`: GitHub Action to automatically regenerate the random verse daily.

### How It Works
1. Run the script locally with:
   ```bash
   node scripts/generate-en-lsv-random.js
### 🙏 Contributor Note

I just wanted to thank you for maintaining this project — it’s such a valuable open resource, and I really appreciate the clean structure and clarity of the data organization.  

I tested this feature locally on **Windows 11** using **Node.js v20.18.0**, verifying that both `bibles/en-lsv/index.json` and `bibles/en-lsv/random.json` are generated correctly for the **en-lsv** version. The script runs without errors and produces valid JSON outputs that can be served statically via jsDelivr.
 
I hope this addition helps extend the project’s usefulness for developers who want simple “Verse of the Day” or random-verse functionality without needing a backend.  

Happy to make any adjustments or follow your preferred structure if you’d like changes! 🙌